### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+CC = g++
+
+ROOTCXXFLAGS := $(shell root-config --cflags)
+ROOTLIBFLAGS := $(shell root-config --libs)
+
+CXXFLAGS = $(ROOTCXXFLAGS)
+LIBFLAGS = $(ROOTLIBFLAGS) 
+
+EXECUTES = COCOS COCOShpc
+
+all: $(EXECUTES)
+
+clean:
+	rm $(EXECUTES)
+
+# executables
+COCOS: ./COCOS.cpp
+	$(CC) ./COCOS.cpp $(CXXFLAGS) -o COCOS $(LIBFLAGS)
+
+COCOShpc: ./COCOShpc.cpp
+	$(CC) ./COCOShpc.cpp $(CXXFLAGS) -o COCOShpc $(LIBFLAGS)


### PR DESCRIPTION
Ich habe ein Makefile geschrieben, dass am HPC funktioniert, wenn man vorher root/6.08.02 als Modul lädt.
Compare.cpp ist gerade nicht drin, weil das von root eingelesen werden soll. Könnte man aber sofort mit reinhauen, wenn man den Quellcode etwas verändert, so dass es kompiliert.