### PR TITLE
Add flexible name of calib file to COCOS.cpp

### DIFF
--- a/include/Settings.hpp
+++ b/include/Settings.hpp
@@ -10,7 +10,7 @@ class Settings{
 private:
     std::map<std::string, long long> fSettingsMap;
     std::string fSettingsFile = "settings.txt";
-    std::string fCalibrationFile;
+    std::string fCalibrationFile = "Calibration.txt";
 
 public:
     Settings();
@@ -29,6 +29,7 @@ public:
     long long GetEndEvalTime() const;
     bool GetTimeLimitation() const;
     std::string GetCalibrationFileName() const;
+    void SetCalibrationFileName(std::string filename);
     void SetStartEvalTime(long long starteval);
     void SetEndEvalTime(long long endeval);
     void SetTimeLimitation(bool inputlimit);

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -85,8 +85,12 @@ void Settings::PrintSettings()
     std::cout << "End time difference [te]:\t" << fSettingsMap["te"] << " ps\n";
     std::cout << "Number of bins [nb]:\t\t" << fSettingsMap["nb"] << "\n";
     std::cout << "Calibration mode [cm]:\t\t" << fSettingsMap["cm"] << "\n";
-    std::cout << "\nDo you want to change something (c for continue)? ";
+    std::cout << "Calibration file [fn]:\t\t" << fCalibrationFile << "\n";
+    std::cout << "\nDo you want to change something (c for continue, x for exit)? ";
     std::cin >> change;
+    if (change == "x"){
+        std::exit(0);
+    }
     ChangeSettings(change);
 }
 
@@ -144,6 +148,11 @@ void Settings::ChangeSettings(std::string change)
         std::cout << "Enter 1 (=read), 2 (=write) or 0 (=none): ";
         std::cin >> calibrationmode;
         SetCalibrationMode(calibrationmode);
+    } else if (change == "fn"){
+        std::string filename;
+        std::cout << "Enter name of Calibration file: ";
+        std::cin >> filename;
+        SetCalibrationFileName(filename);
     } else if (change == "c"){
         goto endmarker;
     } else {
@@ -186,6 +195,11 @@ long long Settings::GetEndEvalTime() const
 bool Settings::GetTimeLimitation() const
 {
     return (bool)(fSettingsMap.find("sl") -> second);
+}
+
+void Settings::SetCalibrationFileName(std::string filename)
+{
+    fCalibrationFile = filename;
 }
 
 void Settings::SetCalibrationMode(int calibrationmode)

--- a/src_exe/COCOS.cpp
+++ b/src_exe/COCOS.cpp
@@ -375,7 +375,7 @@ int main (int argc, char* argv[])
     Settings vSetting;
     vSetting.PrintSettings();
     
-    std::string calibfilename = "Calibration.txt";
+    std::string calibfilename = vSetting.GetCalibrationFileName();
 
 	//############# Ende manuelles Einstellen-Zeug #############//
 	//##########################################################//


### PR DESCRIPTION
Ab jetzt kann man zur Laufzeit des Programms den Namen des zu schreibenden/ zu lesenden Calibrationsfiles veraendern.

RTM