### PR TITLE
change of c++ standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(WEXTRA "-Wextra" OFF)
 
 
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3")
 if(WALL)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 endif()


### PR DESCRIPTION
I changed the C++ standard in CMakeLists.txt from std=c++17 to std=c++11.
The software does not compile on the HPC with std=c++17, don't know why.