### PR TITLE
Fix CheckSettingsFile()

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -67,6 +67,8 @@ bool CheckSettingsFile(std::string file){
     while(getline(ifs, line)){
         if(line[0] == '#'){
             continue;
+        } else if (line[0] == '$'){
+            continue;
         } else if (line[2] != ' '){
             return false;
         }


### PR DESCRIPTION
Da war ein Fehler in der CheckSettings, weil er hat die Kommentarzeilen als Fehler interpretiert, weil da das dritte Symbol kein Leerzeichen ist.
Deswegen auch heute morgen "Wrong layout of settings.txt". Jetzt sollte es gehen